### PR TITLE
[FEAT/#17] API 응답 처리 및 에러 관리 구현

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/global/error/CustomException.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/CustomException.java
@@ -1,0 +1,19 @@
+package com.togedy.togedy_server_v2.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(errorCode.getMessage() + " " + message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // GLOBAL
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에 문제가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에 문제가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 값 또는 형식입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.togedy.togedy_server_v2.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // GLOBAL
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에 문제가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.togedy.togedy_server_v2.global.error;
+
+import com.togedy.togedy_server_v2.global.response.ApiResponse;
+import com.togedy.togedy_server_v2.global.response.ErrorResponse;
+import com.togedy.togedy_server_v2.global.util.ApiUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        return handleException(e, ErrorResponse.of(e.getErrorCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse<?>> handleRuntimeException(RuntimeException e) {
+        return handleException(e, ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return handleException(e, ErrorResponse.of(
+                ErrorCode.INVALID_INPUT_VALUE,
+                ErrorCode.INVALID_INPUT_VALUE.getMessage() + " " + errorMessage)
+        );
+    }
+
+    private ResponseEntity<ApiResponse<?>> handleException(Exception e, ErrorResponse errorResponse) {
+        log.error("[{}] {}: {}", errorResponse.getCode(), e.getClass().getSimpleName(), e.getMessage());
+        return ResponseEntity
+                .status(errorResponse.getStatus())
+                .body(ApiUtil.error(errorResponse));
+    }
+
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/response/ApiResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/response/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.togedy.togedy_server_v2.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"success", "response"})
+public class ApiResponse<T> {
+
+    @JsonProperty(value = "isSuccess")
+    private final boolean success = true;
+
+    @JsonProperty(value = "response")
+    private final T response;
+
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/response/ApiResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/response/ApiResponse.java
@@ -13,9 +13,11 @@ import lombok.Getter;
 public class ApiResponse<T> {
 
     @JsonProperty(value = "isSuccess")
-    private final boolean success = true;
+    private final boolean success;
 
     @JsonProperty(value = "response")
     private final T response;
 
+    @JsonProperty(value = "errorResponse")
+    private final ErrorResponse errorResponse;
 }

--- a/src/main/java/com/togedy/togedy_server_v2/global/response/ErrorResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/response/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.togedy.togedy_server_v2.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"success", "response"})
+public class ErrorResponse {
+
+    @JsonProperty(value = "isSuccess")
+    private final boolean success = false;
+
+    @JsonProperty(value = "status")
+    private final int status;
+
+    @JsonProperty(value = "code")
+    private final String code;
+
+    @JsonProperty(value = "message")
+    private final String message;
+
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/response/ErrorResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/response/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.togedy.togedy_server_v2.global.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.togedy.togedy_server_v2.global.error.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,9 +12,6 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"success", "response"})
 public class ErrorResponse {
-
-    @JsonProperty(value = "isSuccess")
-    private final boolean success = false;
 
     @JsonProperty(value = "status")
     private final int status;
@@ -24,4 +22,19 @@ public class ErrorResponse {
     @JsonProperty(value = "message")
     private final String message;
 
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage() + " " + message)
+                .build();
+    }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/global/util/ApiUtil.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/util/ApiUtil.java
@@ -1,0 +1,37 @@
+package com.togedy.togedy_server_v2.global.util;
+
+import com.togedy.togedy_server_v2.global.error.ErrorCode;
+import com.togedy.togedy_server_v2.global.response.ApiResponse;
+import com.togedy.togedy_server_v2.global.response.ErrorResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiUtil {
+
+    public static <T> ApiResponse<T> success(T response) {
+        return ApiResponse.<T>builder()
+                .response(response)
+                .build();
+    }
+
+    public static ApiResponse<Void> successOnly() {
+        return ApiResponse.<Void>builder()
+                .build();
+    }
+
+    public static ErrorResponse error(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    public static ErrorResponse errorWithMessage (ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage() + " " + message)
+                .build();
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/util/ApiUtil.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/util/ApiUtil.java
@@ -1,6 +1,5 @@
 package com.togedy.togedy_server_v2.global.util;
 
-import com.togedy.togedy_server_v2.global.error.ErrorCode;
 import com.togedy.togedy_server_v2.global.response.ApiResponse;
 import com.togedy.togedy_server_v2.global.response.ErrorResponse;
 import org.springframework.stereotype.Component;
@@ -10,28 +9,22 @@ public class ApiUtil {
 
     public static <T> ApiResponse<T> success(T response) {
         return ApiResponse.<T>builder()
+                .success(true)
                 .response(response)
                 .build();
     }
 
     public static ApiResponse<Void> successOnly() {
         return ApiResponse.<Void>builder()
+                .success(true)
                 .build();
     }
 
-    public static ErrorResponse error(ErrorCode errorCode) {
-        return ErrorResponse.builder()
-                .status(errorCode.getHttpStatus().value())
-                .code(errorCode.getCode())
-                .message(errorCode.getMessage())
+    public static ApiResponse<?> error(ErrorResponse errorResponse) {
+        return ApiResponse.builder()
+                .success(false)
+                .errorResponse(errorResponse)
                 .build();
     }
 
-    public static ErrorResponse errorWithMessage (ErrorCode errorCode, String message) {
-        return ErrorResponse.builder()
-                .status(errorCode.getHttpStatus().value())
-                .code(errorCode.getCode())
-                .message(errorCode.getMessage() + " " + message)
-                .build();
-    }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #17 

## Work Description ✏️
- API 성공 및 실패 응답을 정의하였습니다.
- 전체적인 에러를 관리하기 위한 ErrorCode를 Enum클래스로 구현하였습니다.
- GlobalExceptionHandler를 구현하였으며, 현재 내부 로직의 문제는 **INTERNAL_SERVER_ERROR** 로 처리하고 있습니다.
- DTO의 유효성 검증 실패의 경우 발생하는 **MethodArgumentNotValidException**의 경우 ErrorCode의 **INVALID_INPUT_VALUE**로 처리하고 있으며, API 응답은 **"올바르지 않은 값 또는 형식입니다."** 이후 올바르지 않은 필드에 대한 설명이 뒤에 추가됩니다.

## Uncompleted Tasks 😅
- [ ] API 응답 테스트 필요

## To Reviewers 📢
- 어색한 흐름이나 좋은 리팩토링 방법 있다면 편하게 말씀해주세용
