### PR TITLE
[FEAT/#21] 유저 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           SPRING_DATASOURCE_USERNAME: root
           SPRING_DATASOURCE_PASSWORD: testdb
           SPRING_JPA_HIBERNATE_DDL_AUTO: create-drop
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew clean build --info
 
       - name: Post result

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,java,intellij,gradle
+
+### application-local.yml ###
+src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+	//h2
+	runtimeOnly 'com.h2database:h2'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,15 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/togedy/togedy_server_v2/TogedyServerV2Application.java
+++ b/src/main/java/com/togedy/togedy_server_v2/TogedyServerV2Application.java
@@ -2,8 +2,10 @@ package com.togedy.togedy_server_v2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TogedyServerV2Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/api/UserController.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/api/UserController.java
@@ -1,8 +1,11 @@
-package com.togedy.togedy_server_v2.domain.user.controller;
+package com.togedy.togedy_server_v2.domain.user.api;
 
 import com.togedy.togedy_server_v2.domain.user.dto.CreateUserRequest;
-import com.togedy.togedy_server_v2.domain.user.service.UserService;
+import com.togedy.togedy_server_v2.domain.user.application.UserService;
+import com.togedy.togedy_server_v2.domain.user.dto.LoginUserRequest;
+import com.togedy.togedy_server_v2.domain.user.dto.LoginUserResponse;
 import com.togedy.togedy_server_v2.global.response.ApiResponse;
+import com.togedy.togedy_server_v2.global.security.jwt.JwtTokenInfo;
 import com.togedy.togedy_server_v2.global.util.ApiUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,5 +40,16 @@ public class UserController {
         response.put("userId", userId);
 
         return ApiUtil.success(response);
+    }
+
+    @Operation(summary = "간편 로그인", description = """
+            
+            이메일 기반 간편 로그인 후 JWT 토큰 발급한다.
+            
+            """)
+    @PostMapping("/login")
+    public ApiResponse<LoginUserResponse> loginUser(@Validated @RequestBody LoginUserRequest request) {
+        JwtTokenInfo tokenInfo = userService.signInUser(request.getEmail());
+        return ApiUtil.success(new LoginUserResponse(tokenInfo));
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -21,6 +21,11 @@ public class UserService {
 
     @Transactional
     public Long generateUser(CreateUserRequest request) {
+        // 닉네임 중복 검사
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new UserException(ErrorCode.DUPLICATED_NICKNAME);
+        }
+        // 이메일 중복 검사
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new UserException(ErrorCode.DUPLICATED_EMAIL);
         }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -1,10 +1,12 @@
-package com.togedy.togedy_server_v2.domain.user.service;
+package com.togedy.togedy_server_v2.domain.user.application;
 
 import com.togedy.togedy_server_v2.domain.user.dao.UserRepository;
 import com.togedy.togedy_server_v2.domain.user.dto.CreateUserRequest;
 import com.togedy.togedy_server_v2.domain.user.entity.User;
 import com.togedy.togedy_server_v2.domain.user.exception.UserException;
 import com.togedy.togedy_server_v2.global.error.ErrorCode;
+import com.togedy.togedy_server_v2.global.security.jwt.JwtTokenInfo;
+import com.togedy.togedy_server_v2.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public Long generateUser(CreateUserRequest request) {
@@ -24,5 +27,12 @@ public class UserService {
 
         User user = request.toEntity();
         return userRepository.save(user).getId();
+    }
+
+    public JwtTokenInfo signInUser(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+        return jwtTokenProvider.generateTokenInfo(user.getId(), user.getEmail());
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -20,16 +20,14 @@ public class UserService {
 
     @Transactional
     public Long generateUser(CreateUserRequest request) {
-        // 닉네임 중복 검사
         if (userRepository.existsByNickname(request.getNickname())) {
             throw new UserException(ErrorCode.DUPLICATED_NICKNAME);
         }
-        // 이메일 중복 검사
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new UserException(ErrorCode.DUPLICATED_EMAIL);
         }
 
-        User user = request.toEntity();
+        User user = User.create(request.getNickname(), request.getEmail());
         return userRepository.save(user).getId();
     }
 

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/controller/UserController.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/controller/UserController.java
@@ -1,0 +1,41 @@
+package com.togedy.togedy_server_v2.domain.user.controller;
+
+import com.togedy.togedy_server_v2.domain.user.dto.CreateUserRequest;
+import com.togedy.togedy_server_v2.domain.user.service.UserService;
+import com.togedy.togedy_server_v2.global.response.ApiResponse;
+import com.togedy.togedy_server_v2.global.util.ApiUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/users")
+@Tag(name = "User", description = "유저 관련 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "간편 회원가입", description = """
+            
+            이메일/닉네임으로 회원가입을 한다.
+            
+            """)
+    @PostMapping("/sign-up")
+    public ApiResponse<Map<String, Long>> createUser(@Validated @RequestBody CreateUserRequest request) {
+        Long userId = userService.generateUser(request);
+
+        Map<String, Long> response = new HashMap<>();
+        response.put("userId", userId);
+
+        return ApiUtil.success(response);
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/UserRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Boolean existsByNickname(String nickname);
+
     Boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/UserRepository.java
@@ -1,0 +1,12 @@
+package com.togedy.togedy_server_v2.domain.user.dao;
+
+import com.togedy.togedy_server_v2.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Boolean existsByEmail(String email);
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/UserRepository.java
@@ -4,9 +4,13 @@ import com.togedy.togedy_server_v2.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/CreateUserRequest.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/CreateUserRequest.java
@@ -1,6 +1,5 @@
 package com.togedy.togedy_server_v2.domain.user.dto;
 
-import com.togedy.togedy_server_v2.domain.user.entity.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -19,7 +18,4 @@ public class CreateUserRequest {
     @Email
     private String email;
 
-    public User toEntity() {
-        return User.create(nickname, email);
-    }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/CreateUserRequest.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/CreateUserRequest.java
@@ -1,0 +1,25 @@
+package com.togedy.togedy_server_v2.domain.user.dto;
+
+import com.togedy.togedy_server_v2.domain.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateUserRequest {
+
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Size(max = 10, message = "10자 이내")
+    private String nickname;
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email
+    private String email;
+
+    public User toEntity() {
+        return User.create(nickname, email);
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/LoginUserRequest.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/LoginUserRequest.java
@@ -1,0 +1,15 @@
+package com.togedy.togedy_server_v2.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginUserRequest {
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email
+    private String email;
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/LoginUserResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dto/LoginUserResponse.java
@@ -1,0 +1,17 @@
+package com.togedy.togedy_server_v2.domain.user.dto;
+
+import com.togedy.togedy_server_v2.global.security.jwt.JwtTokenInfo;
+import lombok.Getter;
+
+@Getter
+public class LoginUserResponse {
+
+    private final String accessToken;
+
+    private final String refreshToken;
+
+    public LoginUserResponse(JwtTokenInfo jwtTokenInfo) {
+        this.accessToken = jwtTokenInfo.getAccessToken();
+        this.refreshToken = jwtTokenInfo.getRefreshToken();
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
@@ -31,4 +31,13 @@ public class User extends BaseEntity {
     @Column(name = "status", nullable = false)
     private BaseStatus status;
 
+    private User(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+        this.status = BaseStatus.ACTIVE;
+    }
+
+    public static User create(String nickname, String email) {
+        return new User(nickname, email);
+    }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
@@ -1,0 +1,34 @@
+package com.togedy.togedy_server_v2.domain.user.entity;
+
+import com.togedy.togedy_server_v2.global.entity.BaseEntity;
+import com.togedy.togedy_server_v2.global.enums.BaseStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", updatable = false)
+    private Long id;
+
+    @Column(name = "nickname", length = 10, nullable = false)
+    private String nickname;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private BaseStatus status;
+
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/entity/User.java
@@ -18,10 +18,10 @@ public class User extends BaseEntity {
     @Column(name = "user_id", updatable = false)
     private Long id;
 
-    @Column(name = "nickname", length = 10, nullable = false)
+    @Column(name = "nickname", length = 10, nullable = false, unique = true)
     private String nickname;
 
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     @Column(name = "profile_image_url")
@@ -39,5 +39,9 @@ public class User extends BaseEntity {
 
     public static User create(String nickname, String email) {
         return new User(nickname, email);
+    }
+
+    public void updateStatus(BaseStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/exception/UserException.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/exception/UserException.java
@@ -1,0 +1,9 @@
+package com.togedy.togedy_server_v2.domain.user.exception;
+
+import com.togedy.togedy_server_v2.global.error.CustomException;
+import com.togedy.togedy_server_v2.global.error.ErrorCode;
+
+public class UserException extends CustomException {
+
+    public UserException(ErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/service/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.togedy.togedy_server_v2.domain.user.service;
+
+import com.togedy.togedy_server_v2.domain.user.dao.UserRepository;
+import com.togedy.togedy_server_v2.domain.user.dto.CreateUserRequest;
+import com.togedy.togedy_server_v2.domain.user.entity.User;
+import com.togedy.togedy_server_v2.domain.user.exception.UserException;
+import com.togedy.togedy_server_v2.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long generateUser(CreateUserRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new UserException(ErrorCode.DUPLICATED_EMAIL);
+        }
+
+        User user = request.toEntity();
+        return userRepository.save(user).getId();
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/config/SecurityConfig.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package com.togedy.togedy_server_v2.global.config;
+
+import com.togedy.togedy_server_v2.global.security.jwt.JwtAuthenticationFilter;
+import com.togedy.togedy_server_v2.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().
+                requestMatchers(new AntPathRequestMatcher("/h2-console/**"));
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("api/v2/**").permitAll()
+                        .requestMatchers(PathRequest.toH2Console()).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions.disable())
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("https://www.togedy.shop"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("location", "Authorization"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/entity/BaseEntity.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.togedy.togedy_server_v2.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Column(name="created_at", updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name="updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/enums/BaseStatus.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/enums/BaseStatus.java
@@ -1,0 +1,5 @@
+package com.togedy.togedy_server_v2.global.enums;
+
+public enum BaseStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
@@ -10,7 +10,12 @@ public enum ErrorCode {
 
     // GLOBAL
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에 문제가 발생했습니다."),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 값 또는 형식입니다.");
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 값 또는 형식입니다."),
+
+
+    // USER
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U404", "사용자를 찾을 수 없습니다."),
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U409", "이미 존재하는 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
 
     // USER (2000)
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U2000", "사용자를 찾을 수 없습니다."),
-    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U2001", "이미 존재하는 이메일입니다.");
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "U2001", "이미 존재하는 닉네임입니다."),
+
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U2002", "이미 존재하는 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/error/ErrorCode.java
@@ -12,10 +12,16 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G500", "서버 내부에 문제가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "G400", "올바르지 않은 값 또는 형식입니다."),
 
+    // JWT (1000)
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J1000", "만료된 토큰입니다."),
+    JWT_UNSUPPORTED(HttpStatus.BAD_REQUEST, "J1001", "지원하지 않는 토큰입니다."),
+    JWT_MALFORMED(HttpStatus.BAD_REQUEST, "J1002", "손상된 토큰입니다."),
+    JWT_INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "J1003", "토큰 서명이 유효하지 않습니다."),
+    JWT_INVALID(HttpStatus.UNAUTHORIZED, "J1004", "유효하지 않은 토큰입니다."),
 
-    // USER
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U404", "사용자를 찾을 수 없습니다."),
-    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U409", "이미 존재하는 이메일입니다.");
+    // USER (2000)
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U2000", "사용자를 찾을 수 없습니다."),
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U2001", "이미 존재하는 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/togedy/togedy_server_v2/global/security/AuthUser.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/security/AuthUser.java
@@ -1,0 +1,38 @@
+package com.togedy.togedy_server_v2.global.security;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@Builder
+public class AuthUser implements UserDetails {
+
+    private final Long id;
+
+    private final String email;
+
+    public AuthUser(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.togedy.togedy_server_v2.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal (HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String bearerToken = request.getHeader("Authorization");
+
+        try {
+            if (bearerToken != null && bearerToken.startsWith(JwtTokenProvider.BEARER)) {
+                String token = bearerToken.substring(JwtTokenProvider.BEARER.length());
+
+                if (jwtTokenProvider.validateToken(token)) {
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+            filterChain.doFilter(request, response);
+        } catch (JwtException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"message\": \"" + e.getMessage() + "\"}");
+        }
+
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtException.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtException.java
@@ -1,0 +1,9 @@
+package com.togedy.togedy_server_v2.global.security.jwt;
+
+import com.togedy.togedy_server_v2.global.error.CustomException;
+import com.togedy.togedy_server_v2.global.error.ErrorCode;
+
+public class JwtException extends CustomException {
+
+    public JwtException(ErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtTokenInfo.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtTokenInfo.java
@@ -1,0 +1,20 @@
+package com.togedy.togedy_server_v2.global.security.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JwtTokenInfo {
+
+    private final String accessToken;
+
+    private final String refreshToken;
+
+    public static JwtTokenInfo of(String accessToken, String refreshToken) {
+        return JwtTokenInfo.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,108 @@
+package com.togedy.togedy_server_v2.global.security.jwt;
+
+import com.togedy.togedy_server_v2.global.error.ErrorCode;
+import com.togedy.togedy_server_v2.global.security.AuthUser;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret-key}")
+    private String JWT_SECRET_KEY;
+
+    @Value("${jwt.access-expired-in}")
+    private Long JWT_ACCESS_EXPIRED_IN;
+
+    @Value("${jwt.refresh-expired-in}")
+    private Long JWT_REFRESH_EXPIRED_IN;
+
+    private Key key;
+
+    public static final String BEARER = "Bearer ";
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(JWT_SECRET_KEY));
+    }
+
+    // 토큰 생성
+    public JwtTokenInfo generateTokenInfo(Long userId, String email) {
+        String accessToken = BEARER + createToken(userId, email, JWT_ACCESS_EXPIRED_IN);
+        String refreshToken = BEARER + createToken(userId, email, JWT_REFRESH_EXPIRED_IN);
+        return JwtTokenInfo.of(accessToken, refreshToken);
+    }
+
+    public String createToken(Long userId, String email, Long expireInMs) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("email", email)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expireInMs))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            token = removeBearerPrefix(token);
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new JwtException(ErrorCode.JWT_EXPIRED);
+        } catch (UnsupportedJwtException e) {
+            throw new JwtException(ErrorCode.JWT_UNSUPPORTED);
+        } catch (MalformedJwtException e) {
+            throw new JwtException(ErrorCode.JWT_MALFORMED);
+        } catch (SignatureException e) {
+            throw new JwtException(ErrorCode.JWT_INVALID_SIGNATURE);
+        } catch (IllegalArgumentException e) {
+            throw new JwtException(ErrorCode.JWT_INVALID);
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Authentication getAuthentication(String token) {
+        token = removeBearerPrefix(token);
+        Claims claims = parseClaims(token);
+
+        Long userId = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
+
+        AuthUser authUser = AuthUser.builder()
+                .id(userId)
+                .email(email)
+                .build();
+
+        return new UsernamePasswordAuthenticationToken(authUser, null, null);
+    }
+
+    private String removeBearerPrefix(String token) {
+        return token != null && token.startsWith(BEARER)
+                ? token.substring(BEARER.length())
+                : token;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,18 @@
 spring:
-  application:
-    name: togedy_server_v2
+  profiles:
+    group:
+      "local": "localDB"
+      "dev": "devDB"
+
+---
+server:
+  port: 8080
+
+---
+spring:
+  config:
+    activate:
+      on-profile: "devDB"
 
   datasource:
     url: ${MYSQL_HOST}
@@ -15,3 +27,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+---
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  access-expired-in: 7200000    # 2시간
+  refresh-expired-in: 604800000 # 7일


### PR DESCRIPTION
## Related issue 🛠
- closed #21 

## Work Description ✏️
- JWT, Spring Security와 유저를 구현하였습니다.
- 닉네임과 이메일로 간편 회원가입 및 로그인 API 구현하였습니다.
- 도메인별 Execption을 추가하여 errorCode 처리하였습니다.
- jwt 관련 환경변수 노션에 추가해두었습니다.
- 포스트맨으로 회원가입, 로그인 API 테스트 완료하였습니다.
![image](https://github.com/user-attachments/assets/3e92f3c4-3bd5-4604-b001-670d52349206)
![image](https://github.com/user-attachments/assets/46fdaf2a-18f1-4e19-8f8f-92880e04df6a)



## Uncompleted Tasks 😅
- [ ] 리프레쉬 토큰 도입
- [ ] redis 연결

## To Reviewers 📢
- DDD 설계 및 더 좋은 로직이나 보완할 부분 있으면 말씀해주세용
