### PR TITLE
[MOD/#38] 개인일정 조회 시 카테고리 전체 반환

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dto/GetUserScheduleResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dto/GetUserScheduleResponse.java
@@ -30,13 +30,13 @@ public class GetUserScheduleResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     private LocalTime endTime;
 
-    private Long categoryId;
-
     private String memo;
 
     @JsonProperty("d-day")
     @Schema(name = "d-day", type = "boolean")
     private boolean dDay;
+
+    private CategoryDto category;
 
     public static GetUserScheduleResponse from(UserSchedule userSchedule) {
         return GetUserScheduleResponse.builder()
@@ -45,7 +45,7 @@ public class GetUserScheduleResponse {
                 .startTime(userSchedule.getStartTime())
                 .endDate(userSchedule.getEndDate())
                 .endTime(userSchedule.getEndTime())
-                .categoryId(userSchedule.getCategory().getId())
+                .category(CategoryDto.from(userSchedule.getCategory()))
                 .memo(userSchedule.getMemo())
                 .dDay(userSchedule.isDDay())
                 .build();


### PR DESCRIPTION
## Related issue 🛠
- closed #38 

## Work Description ✏️
- 개인일정 조회 시 기존에 카테고리의 ID를 반환하였는데, 카테고리 데이터 전체를 반환하도록 DTO를 수정하였습니다.


## Uncompleted Tasks 😅
- X

## To Reviewers 📢
- X
