### PR TITLE
[Fix/#143] 카카오 로그인 중복 이메일 오류 수정

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/application/StudyTaskService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/application/StudyTaskService.java
@@ -112,7 +112,9 @@ public class StudyTaskService {
                             .map(DailyPlannerTaskItemDto::from)
                             .toList();
 
-                    Long subjectStudyTime = studyTimeBySubjectId.getOrDefault(studySubject.getId(), 0L);
+                    String subjectStudyTime = TimeUtil.formatSecondsToHms(
+                            studyTimeBySubjectId.getOrDefault(studySubject.getId(), 0L)
+                    );
 
                     return DailyPlannerTaskDto.of(studySubject, subjectStudyTime, taskList);
                 })

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dto/DailyPlannerTaskDto.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dto/DailyPlannerTaskDto.java
@@ -19,15 +19,15 @@ public class DailyPlannerTaskDto {
     @Schema(description = "스터디 과목 색상", type = "string", example = "1")
     private String subjectColor;
 
-    @Schema(description = "해당 과목의 일일 누적 공부 시간(초)", type = "integer", format = "int64", example = "7240")
-    private Long subjectStudyTime;
+    @Schema(description = "해당 과목의 일일 누적 공부 시간", type = "string", example = "02:00:40")
+    private String subjectStudyTime;
 
     @Schema(description = "해당 과목의 태스크 목록")
     private List<DailyPlannerTaskItemDto> taskList;
 
     public static DailyPlannerTaskDto of(
             StudySubject studySubject,
-            Long subjectStudyTime,
+            String subjectStudyTime,
             List<DailyPlannerTaskItemDto> taskList
     ) {
         return DailyPlannerTaskDto.builder()

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/KakaoAuthService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/KakaoAuthService.java
@@ -16,6 +16,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -50,17 +52,15 @@ public class KakaoAuthService {
             user = provider.getUser();
             completed = user.isProfileCompleted();
         } else {
-            if (email != null) {
-                user = userRepository.findByEmail(email).orElse(null);
-            } else {
-                user = null;
-            }
+            Optional<User> existingUser = Optional.ofNullable(email)
+                    .flatMap(userRepository::findByEmail);
 
-            if (user == null) {
+            if (existingUser.isPresent()) {
+                user = existingUser.get();
+                completed = user.isProfileCompleted();
+            } else {
                 user = saveUserHandlingDuplicateEmail(User.createTemp(email));
                 completed = false;
-            } else {
-                completed = user.isProfileCompleted();
             }
 
             authProviderRepository.save(

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/KakaoAuthService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/KakaoAuthService.java
@@ -50,16 +50,22 @@ public class KakaoAuthService {
             user = provider.getUser();
             completed = user.isProfileCompleted();
         } else {
-            if (email != null && userRepository.existsByEmail(email)) {
-                throw new DuplicateEmailException();
+            if (email != null) {
+                user = userRepository.findByEmail(email).orElse(null);
+            } else {
+                user = null;
             }
 
-            user = saveUserHandlingDuplicateEmail(User.createTemp(email));
+            if (user == null) {
+                user = saveUserHandlingDuplicateEmail(User.createTemp(email));
+                completed = false;
+            } else {
+                completed = user.isProfileCompleted();
+            }
 
             authProviderRepository.save(
                     AuthProvider.kakao(user, providerUserId)
             );
-            completed = false;
         }
 
         JwtTokenInfo jwtTokenInfo = authService.issueToken(user.getId());

--- a/src/test/java/com/togedy/togedy_server_v2/domain/planner/application/StudyTaskServiceTest.java
+++ b/src/test/java/com/togedy/togedy_server_v2/domain/planner/application/StudyTaskServiceTest.java
@@ -107,7 +107,7 @@ class StudyTaskServiceTest {
         assertThat(englishPlanner.getSubjectId()).isEqualTo(1L);
         assertThat(englishPlanner.getSubjectName()).isEqualTo("영어");
         assertThat(englishPlanner.getSubjectColor()).isEqualTo("노란색");
-        assertThat(englishPlanner.getSubjectStudyTime()).isEqualTo(720L);
+        assertThat(englishPlanner.getSubjectStudyTime()).isEqualTo("00:12:00");
         assertThat(englishPlanner.getTaskList()).hasSize(2);
         assertThat(englishPlanner.getTaskList().get(0).getTaskId()).isEqualTo(101L);
         assertThat(englishPlanner.getTaskList().get(0).getTaskName()).isEqualTo("영어단어 10개 암기");
@@ -117,7 +117,7 @@ class StudyTaskServiceTest {
         assertThat(mathPlanner.getSubjectId()).isEqualTo(2L);
         assertThat(mathPlanner.getSubjectName()).isEqualTo("수학");
         assertThat(mathPlanner.getSubjectColor()).isEqualTo("파란색");
-        assertThat(mathPlanner.getSubjectStudyTime()).isEqualTo(0L);
+        assertThat(mathPlanner.getSubjectStudyTime()).isEqualTo("00:00:00");
         assertThat(mathPlanner.getTaskList()).isEmpty();
     }
 

--- a/src/test/java/com/togedy/togedy_server_v2/domain/user/application/KakaoAuthServiceTest.java
+++ b/src/test/java/com/togedy/togedy_server_v2/domain/user/application/KakaoAuthServiceTest.java
@@ -1,0 +1,117 @@
+package com.togedy.togedy_server_v2.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.togedy.togedy_server_v2.domain.user.dao.AuthProviderRepository;
+import com.togedy.togedy_server_v2.domain.user.dao.UserRepository;
+import com.togedy.togedy_server_v2.domain.user.dto.KakaoLoginResponse;
+import com.togedy.togedy_server_v2.domain.user.dto.KakaoUserInfoResponse;
+import com.togedy.togedy_server_v2.domain.user.entity.AuthProvider;
+import com.togedy.togedy_server_v2.domain.user.entity.User;
+import com.togedy.togedy_server_v2.domain.user.enums.ProviderType;
+import com.togedy.togedy_server_v2.global.infrastructure.kakao.KakaoApiClient;
+import com.togedy.togedy_server_v2.global.security.jwt.JwtTokenInfo;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoAuthServiceTest {
+
+    @Mock
+    private KakaoApiClient kakaoApiClient;
+
+    @Mock
+    private AuthProviderRepository authProviderRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private KakaoAuthService kakaoAuthService;
+
+    @Test
+    void 기존_이메일_사용자는_카카오_계정을_연결한_뒤_로그인한다() {
+        String kakaoAccessToken = "kakao-access-token";
+        String providerUserId = "12345";
+        String email = "user@test.com";
+
+        KakaoUserInfoResponse kakaoUser = new KakaoUserInfoResponse();
+        ReflectionTestUtils.setField(kakaoUser, "id", 12345L);
+
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount();
+        ReflectionTestUtils.setField(kakaoAccount, "email", email);
+        ReflectionTestUtils.setField(kakaoUser, "kakaoAccount", kakaoAccount);
+
+        User user = User.create("tester", email);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "profileCompleted", true);
+
+        JwtTokenInfo tokenInfo = JwtTokenInfo.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .build();
+
+        given(kakaoApiClient.getUserInfo(kakaoAccessToken)).willReturn(kakaoUser);
+        given(authProviderRepository.findByProviderAndProviderUserId(ProviderType.KAKAO, providerUserId))
+                .willReturn(Optional.empty());
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(authProviderRepository.save(any(AuthProvider.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(authService.issueToken(user.getId())).willReturn(tokenInfo);
+
+        KakaoLoginResponse response = kakaoAuthService.loginWithKakao(kakaoAccessToken);
+
+        assertThat(response.getJwtTokenInfo()).isEqualTo(tokenInfo);
+        assertThat(response.isProfileCompleted()).isTrue();
+        verify(userRepository, never()).save(any(User.class));
+        verify(authProviderRepository).save(any(AuthProvider.class));
+    }
+
+    @Test
+    void 신규_카카오_사용자는_임시_유저를_생성한_뒤_로그인한다() {
+        String kakaoAccessToken = "kakao-access-token";
+        String providerUserId = "67890";
+        String email = "new-user@test.com";
+
+        KakaoUserInfoResponse kakaoUser = new KakaoUserInfoResponse();
+        ReflectionTestUtils.setField(kakaoUser, "id", 67890L);
+
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount();
+        ReflectionTestUtils.setField(kakaoAccount, "email", email);
+        ReflectionTestUtils.setField(kakaoUser, "kakaoAccount", kakaoAccount);
+
+        User savedUser = User.createTemp(email);
+        ReflectionTestUtils.setField(savedUser, "id", 2L);
+
+        JwtTokenInfo tokenInfo = JwtTokenInfo.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .build();
+
+        given(kakaoApiClient.getUserInfo(kakaoAccessToken)).willReturn(kakaoUser);
+        given(authProviderRepository.findByProviderAndProviderUserId(ProviderType.KAKAO, providerUserId))
+                .willReturn(Optional.empty());
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+        given(authProviderRepository.save(any(AuthProvider.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(authService.issueToken(savedUser.getId())).willReturn(tokenInfo);
+
+        KakaoLoginResponse response = kakaoAuthService.loginWithKakao(kakaoAccessToken);
+
+        assertThat(response.getJwtTokenInfo()).isEqualTo(tokenInfo);
+        assertThat(response.isProfileCompleted()).isFalse();
+        verify(userRepository).save(any(User.class));
+        verify(authProviderRepository).save(any(AuthProvider.class));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #143

## Work Description ✏️
- 기존 이메일 회원 카카오 로그인 시 중복 이메일 오류 수정


## Uncompleted Tasks 😅
- [ ] 카카오 로그인 시, 신규/기존 사용자 분기처리
- [ ] 일간 플래너 테스크 조회 시, subjectStudyTime 타입 수정

## To Reviewers 📢
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 공부 시간이 초 단위 숫자에서 HH:MM:SS 문자열로 표시되어 가독성이 향상되었습니다.
  * 카카오 로그인 시 기존 사용자의 프로필 완성 상태가 올바르게 유지되도록 로그인 흐름이 개선되었습니다.

* **Tests**
  * 카카오 인증 시나리오와 공부 시간 표시 관련 단위 테스트가 추가/갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->