### PR TITLE
[FEAT/#140] 유저 회원 탈퇴 API

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/domain/chat/dao/ChatMessageRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/chat/dao/ChatMessageRepository.java
@@ -4,7 +4,9 @@ import com.togedy.togedy_server_v2.domain.chat.entity.ChatMessage;
 import com.togedy.togedy_server_v2.domain.chat.enums.Sender;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
     Optional<ChatMessage> findTopByUserIdAndSenderOrderByCreatedAtDesc(

--- a/src/main/java/com/togedy/togedy_server_v2/domain/chat/dao/ChatMessageRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/chat/dao/ChatMessageRepository.java
@@ -14,4 +14,5 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
             Sender sender
     );
 
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/DailyStudySummaryRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/DailyStudySummaryRepository.java
@@ -11,7 +11,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface DailyStudySummaryRepository extends JpaRepository<DailyStudySummary, Long> {
 
     @Query("""

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/DailyStudySummaryRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/DailyStudySummaryRepository.java
@@ -113,4 +113,6 @@ public interface DailyStudySummaryRepository extends JpaRepository<DailyStudySum
                 AND ds.date = :targetDate
             """)
     List<DailyStudySummaryRow> findAllByStudyIdsAndDate(List<Long> studyIds, LocalDate targetDate);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
@@ -12,4 +12,6 @@ public interface PlannerDailyImageRepository extends JpaRepository<PlannerDailyI
     Optional<PlannerDailyImage> findByUserIdAndDate(Long userId, LocalDate date);
 
     Optional<PlannerDailyImage> findTopByUserIdAndDateLessThanEqualOrderByDateDesc(Long userId, LocalDate date);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
@@ -4,7 +4,9 @@ import com.togedy.togedy_server_v2.domain.planner.entity.PlannerDailyImage;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PlannerDailyImageRepository extends JpaRepository<PlannerDailyImage, Long> {
 
     Optional<PlannerDailyImage> findByUserIdAndDate(Long userId, LocalDate date);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudySubjectRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudySubjectRepository.java
@@ -1,11 +1,11 @@
 package com.togedy.togedy_server_v2.domain.planner.dao;
 
 import com.togedy.togedy_server_v2.domain.planner.entity.StudySubject;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StudySubjectRepository extends JpaRepository<StudySubject, Long> {
@@ -45,4 +45,6 @@ public interface StudySubjectRepository extends JpaRepository<StudySubject, Long
     Long findMaxOrderIndex(Long userId);
 
     Optional<StudySubject> findByNameAndColorAndUserId(String name, String color, Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudySubjectRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudySubjectRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface StudySubjectRepository extends JpaRepository<StudySubject, Long> {
     @Query("""
             SELECT ss

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTaskRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTaskRepository.java
@@ -6,7 +6,9 @@ import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StudyTaskRepository extends JpaRepository<StudyTask, Long> {
     @Query("""
                 SELECT st

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTaskRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTaskRepository.java
@@ -1,7 +1,6 @@
 package com.togedy.togedy_server_v2.domain.planner.dao;
 
 import com.togedy.togedy_server_v2.domain.planner.entity.StudyTask;
-
 import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +19,6 @@ public interface StudyTaskRepository extends JpaRepository<StudyTask, Long> {
             List<Long> studySubjectIds,
             LocalDate date
     );
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTimeRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTimeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+@Repository
 public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTimeRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/StudyTimeRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
@@ -95,4 +96,6 @@ public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
     List<StudyTime> findRunningStudyTimesBefore(
             @Param("summaryEnd") LocalDateTime summaryEnd
     );
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/CategoryRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/CategoryRepository.java
@@ -3,9 +3,9 @@ package com.togedy.togedy_server_v2.domain.schedule.dao;
 import com.togedy.togedy_server_v2.domain.schedule.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
+@Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     @Query("SELECT c FROM Category c where c.user.id = :userId AND c.status = 'ACTIVE'")

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/CategoryRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.togedy.togedy_server_v2.domain.schedule.dao;
 
 import com.togedy.togedy_server_v2.domain.schedule.entity.Category;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -20,4 +21,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
                 AND c.status = 'ACTIVE'
             """)
     boolean existsByNameAndColorAndUserId(String name, String color, Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/UserScheduleRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/UserScheduleRepository.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface UserScheduleRepository extends JpaRepository<UserSchedule, Long> {
 
     @Query("""

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/UserScheduleRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/UserScheduleRepository.java
@@ -46,7 +46,5 @@ public interface UserScheduleRepository extends JpaRepository<UserSchedule, Long
             """)
     Optional<UserSchedule> findByUserIdAndDDayTrue(Long userId);
 
-    void deleteAllById(Long id);
-
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/UserScheduleRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dao/UserScheduleRepository.java
@@ -1,25 +1,25 @@
 package com.togedy.togedy_server_v2.domain.schedule.dao;
 
 import com.togedy.togedy_server_v2.domain.schedule.entity.UserSchedule;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserScheduleRepository extends JpaRepository<UserSchedule, Long> {
 
     @Query("""
-        SELECT us
-        FROM UserSchedule us
-            JOIN FETCH us.category c
-        WHERE us.user.id = :userId
-            AND us.startDate <= :endOfMonth
-            AND COALESCE(us.endDate, us.startDate) >= :startOfMonth
-    """)
+                SELECT us
+                FROM UserSchedule us
+                    JOIN FETCH us.category c
+                WHERE us.user.id = :userId
+                    AND us.startDate <= :endOfMonth
+                    AND COALESCE(us.endDate, us.startDate) >= :startOfMonth
+            """)
     List<UserSchedule> findByUserIdAndYearAndMonth(
             @Param("userId") Long userId,
             @Param("startOfMonth") LocalDate startOfMonth,
@@ -27,23 +27,26 @@ public interface UserScheduleRepository extends JpaRepository<UserSchedule, Long
     );
 
     @Query("""
-        SELECT us
-        FROM UserSchedule us
-            JOIN FETCH us.category c
-        WHERE us.user.id = :userId
-            AND :date BETWEEN us.startDate AND COALESCE(us.endDate, us.startDate)
-    """)
+                SELECT us
+                FROM UserSchedule us
+                    JOIN FETCH us.category c
+                WHERE us.user.id = :userId
+                    AND :date BETWEEN us.startDate AND COALESCE(us.endDate, us.startDate)
+            """)
     List<UserSchedule> findByUserIdAndDate(
             @Param("userId") Long userId,
             @Param("date") LocalDate date
     );
 
     @Query("""
-        SELECT us
-        FROM  UserSchedule us
-        WHERE us.user.id = :userId
-         AND us.dDay = true
-    """)
+                SELECT us
+                FROM  UserSchedule us
+                WHERE us.user.id = :userId
+                 AND us.dDay = true
+            """)
     Optional<UserSchedule> findByUserIdAndDDayTrue(Long userId);
 
+    void deleteAllById(Long id);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/StudyReportRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/StudyReportRepository.java
@@ -2,6 +2,8 @@ package com.togedy.togedy_server_v2.domain.study.dao;
 
 import com.togedy.togedy_server_v2.domain.study.entity.StudyReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StudyReportRepository extends JpaRepository<StudyReport, Long> {
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/StudyRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/StudyRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StudyRepository extends JpaRepository<Study, Long> {
 
     boolean existsByName(String studyName);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/StudyStatisticsRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/StudyStatisticsRepository.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StudyStatisticsRepository extends JpaRepository<StudyStatistics, Long> {
 
     Optional<StudyStatistics> findByStudyId(Long studyId);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/UserStudyRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/UserStudyRepository.java
@@ -7,7 +7,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserStudyRepository extends JpaRepository<UserStudy, Long> {
     Optional<UserStudy> findByStudyIdAndUserId(Long studyId, Long userId);
 

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/UserStudyRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dao/UserStudyRepository.java
@@ -42,4 +42,8 @@ public interface UserStudyRepository extends JpaRepository<UserStudy, Long> {
                 WHERE us.studyId IN :studyIds
             """)
     List<UserStudy> findAllByStudyIds(List<Long> studyIds);
+
+    List<UserStudy> findAllByUserId(Long userId);
+
+    Optional<UserStudy> findFirstByStudyIdAndUserIdNotOrderByCreatedAtAsc(Long studyId, Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/UserStudy.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/UserStudy.java
@@ -87,6 +87,10 @@ public class UserStudy extends BaseEntity {
         return (int) ChronoUnit.DAYS.between(createdDate, now);
     }
 
+    public boolean isLeader() {
+        return StudyRole.LEADER == this.role;
+    }
+
     private void validateRemoveSelf(Long removeUserId) {
         if (this.userId.equals(removeUserId)) {
             throw new StudyLeaderCannotRemoveSelfException();

--- a/src/main/java/com/togedy/togedy_server_v2/domain/university/dao/UserUniversityMethodRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/university/dao/UserUniversityMethodRepository.java
@@ -1,28 +1,28 @@
 package com.togedy.togedy_server_v2.domain.university.dao;
 
 import com.togedy.togedy_server_v2.domain.university.entity.UserUniversityMethod;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserUniversityMethodRepository extends JpaRepository<UserUniversityMethod, Long> {
 
     @Query("""
-        SELECT uum
-        FROM UserUniversityMethod uum
-            JOIN FETCH uum.universityAdmissionMethod uam
-            JOIN FETCH uam.universityAdmissionScheduleList uasl
-            JOIN FETCH uasl.universitySchedule us
-            JOIN FETCH uam.university u
-        WHERE uum.user.id = :userId
-            AND us.startDate <= :endOfMonth
-            AND COALESCE(us.endDate, us.startDate) >= :startOfMonth 
-    """)
+                SELECT uum
+                FROM UserUniversityMethod uum
+                    JOIN FETCH uum.universityAdmissionMethod uam
+                    JOIN FETCH uam.universityAdmissionScheduleList uasl
+                    JOIN FETCH uasl.universitySchedule us
+                    JOIN FETCH uam.university u
+                WHERE uum.user.id = :userId
+                    AND us.startDate <= :endOfMonth
+                    AND COALESCE(us.endDate, us.startDate) >= :startOfMonth 
+            """)
     List<UserUniversityMethod> findByUserIdAndYearAndMonth(
             @Param("userId") Long userId,
             @Param("startOfMonth") LocalDate startOfMonth,
@@ -30,18 +30,21 @@ public interface UserUniversityMethodRepository extends JpaRepository<UserUniver
     );
 
     @Query("""
-        SELECT uum
-        FROM UserUniversityMethod uum
-            JOIN FETCH uum.universityAdmissionMethod uam
-            JOIN FETCH uam.universityAdmissionScheduleList uasl
-            JOIN FETCH uasl.universitySchedule us
-            JOIN FETCH uam.university u
-        WHERE uum.user.id = :userId
-            AND :date BETWEEN us.startDate AND COALESCE(us.endDate, us.startDate)
-    """)
+                SELECT uum
+                FROM UserUniversityMethod uum
+                    JOIN FETCH uum.universityAdmissionMethod uam
+                    JOIN FETCH uam.universityAdmissionScheduleList uasl
+                    JOIN FETCH uasl.universitySchedule us
+                    JOIN FETCH uam.university u
+                WHERE uum.user.id = :userId
+                    AND :date BETWEEN us.startDate AND COALESCE(us.endDate, us.startDate)
+            """)
     List<UserUniversityMethod> findByUserIdAndDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 
-    Optional<UserUniversityMethod> findByUniversityAdmissionMethodIdAndUserId(Long universityAdmissionMethodId, Long userId);
+    Optional<UserUniversityMethod> findByUniversityAdmissionMethodIdAndUserId(Long universityAdmissionMethodId,
+                                                                              Long userId);
 
     boolean existsByUniversityAdmissionMethodIdAndUserId(Long universityAdmissionMethodId, Long userId);
+
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/university/dao/UserUniversityMethodRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/university/dao/UserUniversityMethodRepository.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface UserUniversityMethodRepository extends JpaRepository<UserUniversityMethod, Long> {
 
     @Query("""

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -1,11 +1,19 @@
 package com.togedy.togedy_server_v2.domain.user.application;
 
+import com.togedy.togedy_server_v2.domain.chat.dao.ChatMessageRepository;
 import com.togedy.togedy_server_v2.domain.planner.dao.DailyStudySummaryRepository;
+import com.togedy.togedy_server_v2.domain.planner.dao.PlannerDailyImageRepository;
+import com.togedy.togedy_server_v2.domain.planner.dao.StudySubjectRepository;
+import com.togedy.togedy_server_v2.domain.planner.dao.StudyTaskRepository;
+import com.togedy.togedy_server_v2.domain.planner.dao.StudyTimeRepository;
 import com.togedy.togedy_server_v2.domain.planner.entity.DailyStudySummary;
+import com.togedy.togedy_server_v2.domain.schedule.dao.CategoryRepository;
+import com.togedy.togedy_server_v2.domain.schedule.dao.UserScheduleRepository;
 import com.togedy.togedy_server_v2.domain.study.dao.StudyRepository;
 import com.togedy.togedy_server_v2.domain.study.dao.UserStudyRepository;
 import com.togedy.togedy_server_v2.domain.study.entity.Study;
 import com.togedy.togedy_server_v2.domain.study.entity.UserStudy;
+import com.togedy.togedy_server_v2.domain.university.dao.UserUniversityMethodRepository;
 import com.togedy.togedy_server_v2.domain.user.dao.AuthProviderRepository;
 import com.togedy.togedy_server_v2.domain.user.dao.RefreshTokenRepository;
 import com.togedy.togedy_server_v2.domain.user.dao.UserRepository;
@@ -22,7 +30,6 @@ import com.togedy.togedy_server_v2.domain.user.dto.PatchUserOnboardingRequest;
 import com.togedy.togedy_server_v2.domain.user.entity.AuthProvider;
 import com.togedy.togedy_server_v2.domain.user.entity.User;
 import com.togedy.togedy_server_v2.domain.user.enums.NicknameValidationReason;
-import com.togedy.togedy_server_v2.domain.user.enums.UserStatus;
 import com.togedy.togedy_server_v2.domain.user.event.UserProfileImageRemovedEvent;
 import com.togedy.togedy_server_v2.domain.user.exception.InvalidUserProfileImageException;
 import com.togedy.togedy_server_v2.domain.user.exception.user.DuplicateEmailException;
@@ -77,6 +84,14 @@ public class UserService {
     private final AuthProviderRepository authProviderRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final DailyStudySummaryRepository dailyStudySummaryRepository;
+    private final UserScheduleRepository userScheduleRepository;
+    private final UserUniversityMethodRepository userUniversityMethodRepository;
+    private final StudyTimeRepository studyTimeRepository;
+    private final PlannerDailyImageRepository plannerDailyImageRepository;
+    private final StudySubjectRepository studySubjectRepository;
+    private final StudyTaskRepository studyTaskRepository;
+    private final CategoryRepository categoryRepository;
+    private final ChatMessageRepository chatMessageRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
@@ -267,27 +282,18 @@ public class UserService {
     /**
      * 사용자를 회원 탈퇴 처리한다.
      * <p>
-     * 사용자를 조회한 뒤, 해당 사용자가 참여 중인 모든 스터디에서 탈퇴 처리를 수행한다. 각 스터디에서는 일반 멤버 탈퇴 또는 방장 위임 후 탈퇴 로직이 적용되며, 모든 스터디 처리 이후 사용자 상태를
-     * 비활성화하고 리프레시 토큰을 삭제한다.
+     * 사용자가 참여 중인 스터디 정보와 사용자에 종속된 일정, 플래너, 채팅, 인증 관련 데이터를 순차적으로 삭제한 뒤 마지막으로 사용자 정보를 삭제한다.
      * </p>
      *
      * @param userId 회원 탈퇴할 사용자 ID
-     * @throws UserNotFoundException 사용자가 존재하지 않는 경우
      */
     @Transactional
     public void withdrawUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        List<UserStudy> userStudies = userStudyRepository.findAllByUserId(userId);
-        Map<Long, Study> studyMap = findStudyMap(userStudies);
-
-        for (UserStudy userStudy : userStudies) {
-            withdrawFromStudy(userStudy, studyMap.get(userStudy.getStudyId()));
-        }
-
-        user.updateStatus(UserStatus.INACTIVE);
-        refreshTokenRepository.deleteByUserId(userId);
+        deleteUserStudy(userId);
+        deleteSchedule(userId);
+        deletePlanner(userId);
+        deleteChat(userId);
+        deleteUser(userId);
     }
 
     /**
@@ -526,6 +532,23 @@ public class UserService {
     }
 
     /**
+     * 사용자가 참여 중인 모든 스터디 정보를 삭제한다.
+     * <p>
+     * 사용자-스터디 매핑 정보를 조회한 뒤, 각 스터디에 대해 일반 멤버 탈퇴 또는 방장 위임 후 탈퇴 로직을 수행한다.
+     * </p>
+     *
+     * @param userId 스터디 참여 정보를 삭제할 사용자 ID
+     */
+    private void deleteUserStudy(Long userId) {
+        List<UserStudy> userStudies = userStudyRepository.findAllByUserId(userId);
+        Map<Long, Study> studyMap = findStudyMap(userStudies);
+
+        for (UserStudy userStudy : userStudies) {
+            withdrawFromStudy(userStudy, studyMap.get(userStudy.getStudyId()));
+        }
+    }
+
+    /**
      * 사용자의 참여 스터디 정보를 기반으로 스터디 ID별 스터디 엔티티를 매핑한다.
      * <p>
      * 사용자-스터디 매핑 목록에서 스터디 ID를 추출한 뒤 중복을 제거하고, 해당 스터디들을 조회하여 스터디 ID를 key로 갖는 Map 형태로 반환한다.
@@ -589,5 +612,61 @@ public class UserService {
         userStudy.delegateLeader(nextLeader.get());
         study.decreaseMemberCount();
         userStudyRepository.delete(userStudy);
+    }
+
+    /**
+     * 사용자에 종속된 일정 관련 데이터를 삭제한다.
+     * <p>
+     * 사용자가 등록한 일정, 대학별 전형 정보, 카테고리 정보를 사용자 ID 기준으로 삭제한다.
+     * </p>
+     *
+     * @param userId 일정 관련 데이터를 삭제할 사용자 ID
+     */
+    private void deleteSchedule(Long userId) {
+        userScheduleRepository.deleteAllByUserId(userId);
+        userUniversityMethodRepository.deleteAllByUserId(userId);
+        categoryRepository.deleteAllByUserId(userId);
+    }
+
+    /**
+     * 사용자에 종속된 플래너 관련 데이터를 삭제한다.
+     * <p>
+     * 플래너 일일 이미지, 학습 과목, 학습 태스크, 학습 시간, 일별 학습 요약 정보를 사용자 ID 기준으로 삭제한다.
+     * </p>
+     *
+     * @param userId 플래너 관련 데이터를 삭제할 사용자 ID
+     */
+    private void deletePlanner(Long userId) {
+        plannerDailyImageRepository.deleteAllByUserId(userId);
+        studySubjectRepository.deleteAllByUserId(userId);
+        studyTaskRepository.deleteAllByUserId(userId);
+        studyTimeRepository.deleteAllByUserId(userId);
+        dailyStudySummaryRepository.deleteAllByUserId(userId);
+    }
+
+    /**
+     * 사용자에 종속된 채팅 데이터를 삭제한다.
+     * <p>
+     * 사용자가 생성한 채팅 메시지를 사용자 ID 기준으로 삭제한다.
+     * </p>
+     *
+     * @param userId 채팅 데이터를 삭제할 사용자 ID
+     */
+    private void deleteChat(Long userId) {
+        chatMessageRepository.deleteAllByUserId(userId);
+    }
+
+    /**
+     * 사용자 및 인증 관련 데이터를 삭제한다.
+     * <p>
+     * 사용자에 종속된 인증 제공자 정보와 리프레시 토큰을 먼저 삭제한 뒤, 마지막으로 사용자 정보를 삭제한다.
+     * </p>
+     *
+     * @param userId 삭제할 사용자 ID
+     */
+    private void deleteUser(Long userId) {
+        authProviderRepository.deleteAllByUserId(userId);
+        refreshTokenRepository.deleteByUserId(userId);
+        userRepository.deleteById(userId);
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -604,8 +604,8 @@ public class UserService {
         );
 
         if (nextLeader.isEmpty()) {
-            studyRepository.delete(study);
             userStudyRepository.delete(userStudy);
+            studyRepository.delete(study);
             return;
         }
 

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -289,11 +289,14 @@ public class UserService {
      */
     @Transactional
     public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
         deleteUserStudy(userId);
         deleteSchedule(userId);
         deletePlanner(userId);
+        deleteUser(user);
         deleteChat(userId);
-        deleteUser(userId);
     }
 
     /**
@@ -662,11 +665,12 @@ public class UserService {
      * 사용자에 종속된 인증 제공자 정보와 리프레시 토큰을 먼저 삭제한 뒤, 마지막으로 사용자 정보를 삭제한다.
      * </p>
      *
-     * @param userId 삭제할 사용자 ID
+     * @param user 삭제할 사용자 객체
      */
-    private void deleteUser(Long userId) {
-        authProviderRepository.deleteAllByUserId(userId);
-        refreshTokenRepository.deleteByUserId(userId);
-        userRepository.deleteById(userId);
+    private void deleteUser(User user) {
+        publishImageRemovedEvent(user.getProfileImageUrl());
+        authProviderRepository.deleteAllByUserId(user.getId());
+        refreshTokenRepository.deleteByUserId(user.getId());
+        userRepository.deleteById(user.getId());
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -12,8 +12,8 @@ import com.togedy.togedy_server_v2.domain.user.dao.UserRepository;
 import com.togedy.togedy_server_v2.domain.user.dto.CreateUserRequest;
 import com.togedy.togedy_server_v2.domain.user.dto.GetMyPageResponse;
 import com.togedy.togedy_server_v2.domain.user.dto.GetMySettingsResponse;
-import com.togedy.togedy_server_v2.domain.user.dto.GetNicknameValidationResponse;
 import com.togedy.togedy_server_v2.domain.user.dto.GetNicknameSuggestionResponse;
+import com.togedy.togedy_server_v2.domain.user.dto.GetNicknameValidationResponse;
 import com.togedy.togedy_server_v2.domain.user.dto.MyPageStudyDto;
 import com.togedy.togedy_server_v2.domain.user.dto.PatchMarketingConsentedSettingRequest;
 import com.togedy.togedy_server_v2.domain.user.dto.PatchProfileRequest;
@@ -21,9 +21,9 @@ import com.togedy.togedy_server_v2.domain.user.dto.PatchPushNotificationSettingR
 import com.togedy.togedy_server_v2.domain.user.dto.PatchUserOnboardingRequest;
 import com.togedy.togedy_server_v2.domain.user.entity.AuthProvider;
 import com.togedy.togedy_server_v2.domain.user.entity.User;
-import com.togedy.togedy_server_v2.domain.user.event.UserProfileImageRemovedEvent;
 import com.togedy.togedy_server_v2.domain.user.enums.NicknameValidationReason;
 import com.togedy.togedy_server_v2.domain.user.enums.UserStatus;
+import com.togedy.togedy_server_v2.domain.user.event.UserProfileImageRemovedEvent;
 import com.togedy.togedy_server_v2.domain.user.exception.InvalidUserProfileImageException;
 import com.togedy.togedy_server_v2.domain.user.exception.user.DuplicateEmailException;
 import com.togedy.togedy_server_v2.domain.user.exception.user.DuplicateNicknameException;
@@ -38,14 +38,16 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -66,6 +68,8 @@ public class UserService {
     );
     private static final int MAX_NICKNAME_SUGGESTION_ATTEMPTS = 100;
     private static final int NICKNAME_SUGGESTION_BATCH_SIZE = 10;
+    private final static int MY_PAGE_STUDY_COUNT = 2;
+
     private final S3Service s3Service;
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
@@ -74,8 +78,6 @@ public class UserService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final DailyStudySummaryRepository dailyStudySummaryRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
-
-    private final static int MY_PAGE_STUDY_COUNT = 2;
 
     @Transactional
     public Long generateUser(CreateUserRequest request) {
@@ -262,10 +264,27 @@ public class UserService {
         user.completeOnboarding(request.getNickname(), request.getBirthDate());
     }
 
+    /**
+     * 사용자를 회원 탈퇴 처리한다.
+     * <p>
+     * 사용자를 조회한 뒤, 해당 사용자가 참여 중인 모든 스터디에서 탈퇴 처리를 수행한다. 각 스터디에서는 일반 멤버 탈퇴 또는 방장 위임 후 탈퇴 로직이 적용되며, 모든 스터디 처리 이후 사용자 상태를
+     * 비활성화하고 리프레시 토큰을 삭제한다.
+     * </p>
+     *
+     * @param userId 회원 탈퇴할 사용자 ID
+     * @throws UserNotFoundException 사용자가 존재하지 않는 경우
+     */
     @Transactional
     public void withdrawUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
+
+        List<UserStudy> userStudies = userStudyRepository.findAllByUserId(userId);
+        Map<Long, Study> studyMap = findStudyMap(userStudies);
+
+        for (UserStudy userStudy : userStudies) {
+            withdrawFromStudy(userStudy, studyMap.get(userStudy.getStudyId()));
+        }
 
         user.updateStatus(UserStatus.INACTIVE);
         refreshTokenRepository.deleteByUserId(userId);
@@ -504,5 +523,71 @@ public class UserService {
             }
             throw e;
         }
+    }
+
+    /**
+     * 사용자의 참여 스터디 정보를 기반으로 스터디 ID별 스터디 엔티티를 매핑한다.
+     * <p>
+     * 사용자-스터디 매핑 목록에서 스터디 ID를 추출한 뒤 중복을 제거하고, 해당 스터디들을 조회하여 스터디 ID를 key로 갖는 Map 형태로 반환한다.
+     * </p>
+     *
+     * @param userStudies 사용자-스터디 매핑 목록
+     * @return 스터디 ID 기준 스터디 매핑 정보
+     */
+    private Map<Long, Study> findStudyMap(List<UserStudy> userStudies) {
+        List<Long> studyIds = userStudies.stream()
+                .map(UserStudy::getStudyId)
+                .distinct()
+                .toList();
+
+        return studyRepository.findAllByIds(studyIds)
+                .stream()
+                .collect(Collectors.toMap(Study::getId, Function.identity()));
+    }
+
+    /**
+     * 사용자-스터디 매핑 정보를 바탕으로 스터디 탈퇴를 처리한다.
+     * <p>
+     * 사용자가 방장인 경우 방장 전용 탈퇴 로직을 수행하고, 일반 멤버인 경우 스터디 인원을 감소시킨 뒤 참여 정보를 삭제한다.
+     * </p>
+     *
+     * @param userStudy 탈퇴 대상 사용자-스터디 매핑 정보
+     * @param study     탈퇴 대상 스터디
+     */
+    private void withdrawFromStudy(UserStudy userStudy, Study study) {
+        if (userStudy.isLeader()) {
+            withdrawLeader(userStudy, study);
+            return;
+        }
+
+        study.decreaseMemberCount();
+        userStudyRepository.delete(userStudy);
+    }
+
+    /**
+     * 방장 사용자의 스터디 탈퇴를 처리한다.
+     * <p>
+     * 같은 스터디의 다른 참여자 중 가장 먼저 가입한 사용자를 다음 방장으로 위임한다. 위임할 사용자가 없는 경우 스터디를 삭제하며, 위임할 사용자가 있는 경우 방장 권한을 넘긴 뒤 스터디 인원을 감소시키고
+     * 기존 방장의 참여 정보를 삭제한다.
+     * </p>
+     *
+     * @param userStudy 탈퇴 대상 방장의 사용자-스터디 매핑 정보
+     * @param study     탈퇴 대상 스터디
+     */
+    private void withdrawLeader(UserStudy userStudy, Study study) {
+        Optional<UserStudy> nextLeader = userStudyRepository.findFirstByStudyIdAndUserIdNotOrderByCreatedAtAsc(
+                userStudy.getStudyId(),
+                userStudy.getUserId()
+        );
+
+        if (nextLeader.isEmpty()) {
+            studyRepository.delete(study);
+            userStudyRepository.delete(userStudy);
+            return;
+        }
+
+        userStudy.delegateLeader(nextLeader.get());
+        study.decreaseMemberCount();
+        userStudyRepository.delete(userStudy);
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/AuthProviderRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/AuthProviderRepository.java
@@ -2,12 +2,14 @@ package com.togedy.togedy_server_v2.domain.user.dao;
 
 import com.togedy.togedy_server_v2.domain.user.entity.AuthProvider;
 import com.togedy.togedy_server_v2.domain.user.enums.ProviderType;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface AuthProviderRepository extends JpaRepository<AuthProvider, Long> {
 
     Optional<AuthProvider> findByProviderAndProviderUserId(ProviderType provider, String providerUserId);
 
+    void deleteAllByUserId(Long userId);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #140 

## Work Description ✏️
- 유저 Hard delete 구현
- 유저 회원 탈퇴 시 기존에 속해있던 스터디 탈퇴하며 본인이 방장인 경우 가장 먼저 스터디에 입장한 유저에게 방장을 위임

## Uncompleted Tasks 😅
- [ ] 카카오 Unlink

## To Reviewers 📢
- 카카오와 연동되어 있는 계정 정보도 삭제할 필요가 있어 추가 구현 부탁드립니다.
- 플래너 이미지 삭제 또한 처리가 필요할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 사용자 계정 탈퇴 시 스터디, 일정, 플래너, 채팅 등 연관 데이터가 순서대로 안전하게 완전 삭제되도록 개선했습니다.
  * 스터디 탈퇴 시 리더 이탈에 대한 후속 리더 선출과 멤버 수 조정이 안정적으로 처리되도록 개선했습니다.

* **내부 개선**
  * 여러 도메인에서 사용자별 대량 삭제를 지원해 데이터 정합성과 삭제 성능을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->