### PR TITLE
[FIX/#147] 회원탈퇴 로직 추가 구현 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,7 @@ jobs:
             export BUCKET_NAME='${{ secrets.BUCKET_NAME }}'
             export MONGODB_URI='${{ secrets.MONGODB_URI }}'
             export AI_SERVER_URL='${{ secrets.AI_SERVER_URL }}'
+            export KAKAO_ADMIN_KEY='${{ secrets.KAKAO_ADMIN_KEY }}'
             
             cd ${{ secrets.PROJECT_PATH }}infra/script
             chmod +x deploy.sh

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       BUCKET_NAME: ${BUCKET_NAME}
       MONGODB_URI: ${MONGODB_URI}
       AI_SERVER_URL: ${AI_SERVER_URL}
+      KAKAO_ADMIN_KEY: ${KAKAO_ADMIN_KEY}
     depends_on:
       redis:
         condition: service_healthy

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
@@ -2,6 +2,7 @@ package com.togedy.togedy_server_v2.domain.planner.dao;
 
 import com.togedy.togedy_server_v2.domain.planner.entity.PlannerDailyImage;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,6 +13,8 @@ public interface PlannerDailyImageRepository extends JpaRepository<PlannerDailyI
     Optional<PlannerDailyImage> findByUserIdAndDate(Long userId, LocalDate date);
 
     Optional<PlannerDailyImage> findTopByUserIdAndDateLessThanEqualOrderByDateDesc(Long userId, LocalDate date);
+
+    List<PlannerDailyImage> findAllByUserId(Long userId);
 
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/dao/PlannerDailyImageRepository.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,7 +15,14 @@ public interface PlannerDailyImageRepository extends JpaRepository<PlannerDailyI
 
     Optional<PlannerDailyImage> findTopByUserIdAndDateLessThanEqualOrderByDateDesc(Long userId, LocalDate date);
 
-    List<PlannerDailyImage> findAllByUserId(Long userId);
+    @Query("""
+            SELECT p.imageUrl
+            FROM PlannerDailyImage p
+            WHERE p.userId = :userId
+                AND p.imageUrl IS NOT NULL
+                AND p.imageUrl <> ''
+            """)
+    List<String> findImageUrlsByUserId(Long userId);
 
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/planner/event/PlannerImageRemovedEvent.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/planner/event/PlannerImageRemovedEvent.java
@@ -1,0 +1,6 @@
+package com.togedy.togedy_server_v2.domain.planner.event;
+
+import com.togedy.togedy_server_v2.global.event.ImageRemovedEvent;
+
+public record PlannerImageRemovedEvent(String imageUrl) implements ImageRemovedEvent {
+}

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -60,6 +60,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -97,6 +98,7 @@ public class UserService {
     private final CategoryRepository categoryRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final TransactionTemplate transactionTemplate;
 
     @Transactional
     public Long generateUser(CreateUserRequest request) {
@@ -291,17 +293,9 @@ public class UserService {
      *
      * @param userId 회원 탈퇴할 사용자 ID
      */
-    @Transactional
     public void withdrawUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
         unlinkKakaoIfNeeded(userId);
-        deleteUserStudy(userId);
-        deleteSchedule(userId);
-        deletePlanner(userId);
-        deleteChat(userId);
-        deleteUser(user);
+        transactionTemplate.executeWithoutResult(status -> withdrawUserData(userId));
     }
 
     /**
@@ -542,6 +536,17 @@ public class UserService {
     private void unlinkKakaoIfNeeded(Long userId) {
         authProviderRepository.findByUserIdAndProvider(userId, ProviderType.KAKAO)
                 .ifPresent(provider -> kakaoApiClient.unlinkByAdminKey(Long.parseLong(provider.getProviderUserId())));
+    }
+
+    protected void withdrawUserData(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        deleteUserStudy(userId);
+        deleteSchedule(userId);
+        deletePlanner(userId);
+        deleteChat(userId);
+        deleteUser(user);
     }
 
     /**

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -7,7 +7,6 @@ import com.togedy.togedy_server_v2.domain.planner.dao.StudySubjectRepository;
 import com.togedy.togedy_server_v2.domain.planner.dao.StudyTaskRepository;
 import com.togedy.togedy_server_v2.domain.planner.dao.StudyTimeRepository;
 import com.togedy.togedy_server_v2.domain.planner.entity.DailyStudySummary;
-import com.togedy.togedy_server_v2.domain.planner.entity.PlannerDailyImage;
 import com.togedy.togedy_server_v2.domain.planner.event.PlannerImageRemovedEvent;
 import com.togedy.togedy_server_v2.domain.schedule.dao.CategoryRepository;
 import com.togedy.togedy_server_v2.domain.schedule.dao.UserScheduleRepository;
@@ -672,9 +671,7 @@ public class UserService {
     }
 
     private void publishPlannerImageRemovedEvents(Long userId) {
-        plannerDailyImageRepository.findAllByUserId(userId).stream()
-                .map(PlannerDailyImage::getImageUrl)
-                .filter(imageUrl -> imageUrl != null && !imageUrl.isBlank())
+        plannerDailyImageRepository.findImageUrlsByUserId(userId).stream()
                 .forEach(imageUrl -> applicationEventPublisher.publishEvent(new PlannerImageRemovedEvent(imageUrl)));
     }
 

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -54,6 +54,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
@@ -64,6 +65,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserService {
 
@@ -294,8 +296,9 @@ public class UserService {
      * @param userId 회원 탈퇴할 사용자 ID
      */
     public void withdrawUser(Long userId) {
-        unlinkKakaoIfNeeded(userId);
+        Long kakaoUserId = findKakaoUserId(userId).orElse(null);
         transactionTemplate.executeWithoutResult(status -> withdrawUserData(userId));
+        unlinkKakaoIfNeeded(kakaoUserId);
     }
 
     /**
@@ -533,9 +536,22 @@ public class UserService {
         }
     }
 
-    private void unlinkKakaoIfNeeded(Long userId) {
-        authProviderRepository.findByUserIdAndProvider(userId, ProviderType.KAKAO)
-                .ifPresent(provider -> kakaoApiClient.unlinkByAdminKey(Long.parseLong(provider.getProviderUserId())));
+    private Optional<Long> findKakaoUserId(Long userId) {
+        return authProviderRepository.findByUserIdAndProvider(userId, ProviderType.KAKAO)
+                .map(AuthProvider::getProviderUserId)
+                .map(Long::parseLong);
+    }
+
+    private void unlinkKakaoIfNeeded(Long kakaoUserId) {
+        if (kakaoUserId == null) {
+            return;
+        }
+
+        try {
+            kakaoApiClient.unlinkByAdminKey(kakaoUserId);
+        } catch (RuntimeException e) {
+            log.warn("Kakao unlink failed after local withdrawal completion. kakaoUserId={}", kakaoUserId, e);
+        }
     }
 
     protected void withdrawUserData(Long userId) {

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -7,6 +7,8 @@ import com.togedy.togedy_server_v2.domain.planner.dao.StudySubjectRepository;
 import com.togedy.togedy_server_v2.domain.planner.dao.StudyTaskRepository;
 import com.togedy.togedy_server_v2.domain.planner.dao.StudyTimeRepository;
 import com.togedy.togedy_server_v2.domain.planner.entity.DailyStudySummary;
+import com.togedy.togedy_server_v2.domain.planner.entity.PlannerDailyImage;
+import com.togedy.togedy_server_v2.domain.planner.event.PlannerImageRemovedEvent;
 import com.togedy.togedy_server_v2.domain.schedule.dao.CategoryRepository;
 import com.togedy.togedy_server_v2.domain.schedule.dao.UserScheduleRepository;
 import com.togedy.togedy_server_v2.domain.study.dao.StudyRepository;
@@ -649,6 +651,7 @@ public class UserService {
      * @param userId 플래너 관련 데이터를 삭제할 사용자 ID
      */
     private void deletePlanner(Long userId) {
+        publishPlannerImageRemovedEvents(userId);
         plannerDailyImageRepository.deleteAllByUserId(userId);
         studySubjectRepository.deleteAllByUserId(userId);
         studyTaskRepository.deleteAllByUserId(userId);
@@ -666,6 +669,13 @@ public class UserService {
      */
     private void deleteChat(Long userId) {
         chatMessageRepository.deleteAllByUserId(userId);
+    }
+
+    private void publishPlannerImageRemovedEvents(Long userId) {
+        plannerDailyImageRepository.findAllByUserId(userId).stream()
+                .map(PlannerDailyImage::getImageUrl)
+                .filter(imageUrl -> imageUrl != null && !imageUrl.isBlank())
+                .forEach(imageUrl -> applicationEventPublisher.publishEvent(new PlannerImageRemovedEvent(imageUrl)));
     }
 
     /**

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/application/UserService.java
@@ -30,6 +30,7 @@ import com.togedy.togedy_server_v2.domain.user.dto.PatchUserOnboardingRequest;
 import com.togedy.togedy_server_v2.domain.user.entity.AuthProvider;
 import com.togedy.togedy_server_v2.domain.user.entity.User;
 import com.togedy.togedy_server_v2.domain.user.enums.NicknameValidationReason;
+import com.togedy.togedy_server_v2.domain.user.enums.ProviderType;
 import com.togedy.togedy_server_v2.domain.user.event.UserProfileImageRemovedEvent;
 import com.togedy.togedy_server_v2.domain.user.exception.InvalidUserProfileImageException;
 import com.togedy.togedy_server_v2.domain.user.exception.user.DuplicateEmailException;
@@ -39,6 +40,7 @@ import com.togedy.togedy_server_v2.domain.user.exception.user.NicknameContainsBa
 import com.togedy.togedy_server_v2.domain.user.exception.user.UserNotFoundException;
 import com.togedy.togedy_server_v2.global.enums.BadWords;
 import com.togedy.togedy_server_v2.global.enums.ImageCategory;
+import com.togedy.togedy_server_v2.global.infrastructure.kakao.KakaoApiClient;
 import com.togedy.togedy_server_v2.global.service.S3Service;
 import com.togedy.togedy_server_v2.global.util.TimeUtil;
 import java.util.ArrayList;
@@ -78,6 +80,7 @@ public class UserService {
     private final static int MY_PAGE_STUDY_COUNT = 2;
 
     private final S3Service s3Service;
+    private final KakaoApiClient kakaoApiClient;
     private final UserRepository userRepository;
     private final StudyRepository studyRepository;
     private final UserStudyRepository userStudyRepository;
@@ -292,11 +295,12 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
+        unlinkKakaoIfNeeded(userId);
         deleteUserStudy(userId);
         deleteSchedule(userId);
         deletePlanner(userId);
-        deleteUser(user);
         deleteChat(userId);
+        deleteUser(user);
     }
 
     /**
@@ -532,6 +536,11 @@ public class UserService {
             }
             throw e;
         }
+    }
+
+    private void unlinkKakaoIfNeeded(Long userId) {
+        authProviderRepository.findByUserIdAndProvider(userId, ProviderType.KAKAO)
+                .ifPresent(provider -> kakaoApiClient.unlinkByAdminKey(Long.parseLong(provider.getProviderUserId())));
     }
 
     /**

--- a/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/AuthProviderRepository.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/user/dao/AuthProviderRepository.java
@@ -11,5 +11,7 @@ public interface AuthProviderRepository extends JpaRepository<AuthProvider, Long
 
     Optional<AuthProvider> findByProviderAndProviderUserId(ProviderType provider, String providerUserId);
 
+    Optional<AuthProvider> findByUserIdAndProvider(Long userId, ProviderType provider);
+
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/togedy/togedy_server_v2/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/config/RestTemplateConfig.java
@@ -2,13 +2,17 @@ package com.togedy.togedy_server_v2.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(3000);
+        requestFactory.setReadTimeout(5000);
+        return new RestTemplate(requestFactory);
     }
 
 }

--- a/src/main/java/com/togedy/togedy_server_v2/global/infrastructure/kakao/KakaoApiClient.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/infrastructure/kakao/KakaoApiClient.java
@@ -24,6 +24,9 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class KakaoApiClient {
 
+    private static final String KAKAO_NOT_LINKED_ERROR_CODE = "-101";
+    private static final String KAKAO_INVALID_ACCOUNT_ERROR_CODE = "-103";
+
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
@@ -77,10 +80,24 @@ public class KakaoApiClient {
                     String.class
             );
         } catch (HttpClientErrorException e) {
+            if (isIgnorableUnlinkException(e)) {
+                log.info("Skip Kakao unlink for userId={} because user is already unlinked or unavailable.", kakaoUserId);
+                return;
+            }
             throw mapKakaoClientException(e);
         } catch (RestClientException e) {
             throw new KakaoApiErrorException();
         }
+    }
+
+    private boolean isIgnorableUnlinkException(HttpClientErrorException e) {
+        if (e.getStatusCode() != HttpStatus.BAD_REQUEST) {
+            return false;
+        }
+
+        KakaoErrorPayload errorPayload = parseErrorPayload(e.getResponseBodyAsString());
+        return KAKAO_NOT_LINKED_ERROR_CODE.equals(errorPayload.code())
+                || KAKAO_INVALID_ACCOUNT_ERROR_CODE.equals(errorPayload.code());
     }
 
     private RuntimeException mapKakaoClientException(HttpClientErrorException e) {

--- a/src/main/java/com/togedy/togedy_server_v2/global/infrastructure/kakao/KakaoApiClient.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/infrastructure/kakao/KakaoApiClient.java
@@ -12,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -28,6 +30,12 @@ public class KakaoApiClient {
     @Value("${kakao.api.url.user-info}")
     private String kakaoUserInfoUrl;
 
+    @Value("${kakao.api.url.unlink}")
+    private String kakaoUnlinkUrl;
+
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
+
     public KakaoUserInfoResponse getUserInfo(String accessToken) {
         try {
             HttpHeaders headers = new HttpHeaders();
@@ -43,6 +51,31 @@ public class KakaoApiClient {
                     KakaoUserInfoResponse.class
             );
             return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw mapKakaoClientException(e);
+        } catch (RestClientException e) {
+            throw new KakaoApiErrorException();
+        }
+    }
+
+    public void unlinkByAdminKey(Long kakaoUserId) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("target_id_type", "user_id");
+            body.add("target_id", String.valueOf(kakaoUserId));
+
+            HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(body, headers);
+
+            restTemplate.exchange(
+                    kakaoUnlinkUrl,
+                    HttpMethod.POST,
+                    entity,
+                    String.class
+            );
         } catch (HttpClientErrorException e) {
             throw mapKakaoClientException(e);
         } catch (RestClientException e) {

--- a/src/main/java/com/togedy/togedy_server_v2/global/infrastructure/kakao/KakaoApiClient.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/infrastructure/kakao/KakaoApiClient.java
@@ -84,7 +84,7 @@ public class KakaoApiClient {
                 log.info("Skip Kakao unlink for userId={} because user is already unlinked or unavailable.", kakaoUserId);
                 return;
             }
-            throw mapKakaoClientException(e);
+            throw new KakaoApiErrorException();
         } catch (RestClientException e) {
             throw new KakaoApiErrorException();
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,9 +86,11 @@ spring:
 
 ---
 kakao:
+  admin-key: ${KAKAO_ADMIN_KEY}
   api:
     url:
       user-info: https://kapi.kakao.com/v2/user/me
+      unlink: https://kapi.kakao.com/v1/user/unlink
 
 ---
 ai:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,6 +37,9 @@ jwt:
   access-expired-in: 3600000
   refresh-expired-in: 1209600000
 
+kakao:
+  admin-key: test-admin-key
+
 ai:
   server:
     url: http://dummy-ai-server


### PR DESCRIPTION
## Related issue 🛠
- closed #147

## Work Description ✏️
- 회원 탈퇴 시 카카오 unlink 및 플래너 이미지 삭제 로직 추가 구현


## Uncompleted Tasks 😅


## To Reviewers 📢
- application.yml에 KAKAO_ADMIN_KEY가 추가되었습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 탈퇴 시 연결된 카카오 계정 자동 해제 기능 추가
  * 플래너 이미지 삭제 시 이미지 삭제 이벤트 발행으로 외부 이미지 정리 지원
  * 사용자별 플래너 이미지 URL 복수 조회 기능 추가

* **Bug Fixes / Improvements**
  * 카카오 연동 예외 처리 강화로 로컬 탈퇴 보장 및 경고 로깅 추가
  * 외부 API 호출 타임아웃 설정 적용으로 네트워크 안정성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->