### PR TITLE
[FIX/#150] 스터디 오류 수정

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/application/StudyTierService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/application/StudyTierService.java
@@ -85,7 +85,7 @@ public class StudyTierService {
                             .studyId(challengeStudy.getId())
                             .build());
 
-            studyStatistics.applyChallengeSuccess(challengeStudy, completedMembers, targetDate);
+            studyStatistics.applyChallengeResult(challengeStudy, completedMembers, targetDate);
             studyStatisticsRepository.save(studyStatistics);
         }
     }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dto/GetStudyResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dto/GetStudyResponse.java
@@ -61,7 +61,7 @@ public class GetStudyResponse {
                 .studyDescription(study.getDescription())
                 .studyImageUrl(study.getImageUrl())
                 .studyTag(study.getTag().getDescription())
-                .studyTier(study.getTier().getName())
+                .studyTier(study.getTier() != null ? study.getTier().getName() : null)
                 .studyMemberCount(study.getMemberCount())
                 .completedMemberCount(completedMemberCount)
                 .studyMemberLimit(study.getMemberLimit())

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/dto/StudySearchDto.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/dto/StudySearchDto.java
@@ -50,7 +50,7 @@ public class StudySearchDto {
                 .studyName(study.getName())
                 .studyDescription(study.getDescription())
                 .studyTag(study.getTag().getDescription())
-                .studyTier(study.getTier().getName())
+                .studyTier(study.getTier() != null ? study.getTier().getName() : null)
                 .studyLeaderImageUrl(studyLeaderImageUrl)
                 .studyMemberCount(study.getMemberCount())
                 .studyMemberLimit(study.getMemberLimit())

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/Study.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/Study.java
@@ -76,7 +76,7 @@ public class Study extends BaseEntity {
     private String password;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "tier", nullable = false, columnDefinition = "varchar(20)")
+    @Column(name = "tier", nullable = true, columnDefinition = "varchar(20)")
     private StudyTier tier;
 
     @Builder
@@ -105,7 +105,7 @@ public class Study extends BaseEntity {
         this.tag = tag;
         this.imageUrl = imageUrl;
         this.password = password;
-        this.tier = StudyTier.BRONZE1;
+        this.tier = type == StudyType.CHALLENGE ? StudyTier.BRONZE1 : null;
     }
 
     public void updateInformation(

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/Study.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/Study.java
@@ -221,6 +221,10 @@ public class Study extends BaseEntity {
     }
 
     public void updateTier(StudyStatistics studyStatistics) {
+        if (!isChallengeStudy()) {
+            return;
+        }
+
         StudyTier studyTier = StudyTier.fromScore(studyStatistics.getScore());
         if (!this.tier.equals(studyTier)) {
             this.tier = studyTier;

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
@@ -52,7 +52,7 @@ public class StudyStatistics {
     }
 
     public void applyChallengeResult(Study study, int completedMemberCount, LocalDate targetDate) {
-        if (targetDate.equals(this.updatedDate)) {
+        if (targetDate.isAfter(this.updatedDate)) {
             return;
         }
 

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
@@ -51,12 +51,20 @@ public class StudyStatistics {
         this.updatedDate = LocalDate.MIN;
     }
 
-    public void applyChallengeSuccess(Study study, int completedMemberCount, LocalDate targetDate) {
+    public void applyChallengeResult(Study study, int completedMemberCount, LocalDate targetDate) {
+        if (targetDate.equals(this.updatedDate)) {
+            return;
+        }
+
+        this.updatedDate = targetDate;
+
         if (study.isChallengeSuccessful(completedMemberCount)) {
             this.streakDays++;
             this.score += calculateStudyScore(study, completedMemberCount);
+            return;
         }
-        this.updatedDate = targetDate;
+
+        this.streakDays = 0;
     }
 
     private long calculateStudyScore(Study study, int completeMemberCount) {


### PR DESCRIPTION
## Related issue 🛠
- closed #150

## Work Description ✏️
- `Study` 테이블 `tier` 컬럼 nullable 허용 및 일반 스터디 생성 시 티어를 부여하던 오류 수정
- 챌린지 스터디가 챌린지를 실패할 경우 `StudyStatistics`테이블 `streakDays` 컬럼 0 초기화

## Uncompleted Tasks 😅
X

## To Reviewers 📢
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 스터디 티어가 null일 때 발생하던 오류 수정 — 조회 응답이 안전하게 처리됩니다.
  * 비챌린지 유형 스터디는 이제 티어 없이 생성 가능하도록 변경.

* **동작 개선**
  * 챌린지 결과 처리 로직 안정화 — 날짜 검증 추가 및 연속일/점수 갱신 규칙 정비.
  * 비챌린지에 대한 티어 갱신은 더 이상 수행되지 않음.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->