### PR TITLE
[MOD/#159] 캘린더 일별 조회 API 응답 추가

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/application/CalendarService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/application/CalendarService.java
@@ -30,11 +30,11 @@ public class CalendarService {
     private final UserUniversityMethodRepository userUniversityMethodRepository;
 
     /**
-     * 유저의 D-Day 일정까지 남은 일 수와 함께 해당 월에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.
+     * 유저의 해당 월에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.
      *
      * @param month  년도 및 월 정보(yyyy-MM)
      * @param userId 유저ID
-     * @return D-day 일정까지 남은 일 수 및 기간 순으로 정렬된 월별 개인 일정 및 대학 일정 DTO
+     * @return 기간 순으로 정렬된 월별 개인 일정 및 대학 일정 DTO
      */
     public GetMonthlyCalendarResponse findMonthlyCalendar(YearMonth month, Long userId) {
         LocalDate startOfMonth = month.atDay(1);
@@ -48,11 +48,11 @@ public class CalendarService {
     }
 
     /**
-     * 유저가 해당 날짜에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.
+     * 유저의 D-Day 일정까지 남은 일 수와 함께 해당 날짜에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.
      *
      * @param date   년도, 월, 날짜 정보 (yyyy-MM-dd)
      * @param userId 유저ID
-     * @return 기간 순으로 정렬된 일별 유저 및 대학 일정 DTO
+     * @return D-day 일정까지 남은 일 수 및 기간 순으로 정렬된 일별 유저 및 대학 일정 DTO
      */
     public GetDailyCalendarResponse findDailyCalendar(LocalDate date, Long userId) {
         Integer remainingDays = calculateRemainingDays(date, userId);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/application/CalendarService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/application/CalendarService.java
@@ -34,11 +34,11 @@ public class CalendarService {
     private final UserService userService;
 
     /**
-     * 유저가 해당 월에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.
+     * 유저의 D-Day 일정까지 남은 일 수와 함께 해당 월에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.
      *
      * @param month  년도 및 월 정보(yyyy-MM)
      * @param userId 유저ID
-     * @return 기간 순으로 정렬된 월별 개인 일정 및 대학 일정 DTO
+     * @return D-day 일정까지 남은 일 수 및 기간 순으로 정렬된 월별 개인 일정 및 대학 일정 DTO
      */
     public GetMonthlyCalendarResponse findMonthlyCalendar(YearMonth month, Long userId) {
         LocalDate startOfMonth = month.atDay(1);
@@ -59,11 +59,11 @@ public class CalendarService {
      * @return 기간 순으로 정렬된 일별 유저 및 대학 일정 DTO
      */
     public GetDailyCalendarResponse findDailyCalendar(LocalDate date, Long userId) {
+        Integer remainingDays = calculateRemainingDays(date, userId);
         List<DailyScheduleListDto> dailyScheduleList = new ArrayList<>(findDailyUserSchedule(userId, date));
         dailyScheduleList.addAll(findDailyUniversitySchedule(userId, date));
         dailyScheduleList.sort(scheduleComparator());
-
-        return GetDailyCalendarResponse.from(dailyScheduleList);
+        return GetDailyCalendarResponse.from(remainingDays, dailyScheduleList);
     }
 
     /**
@@ -77,7 +77,7 @@ public class CalendarService {
 
         if (dDaySchedule.isPresent()) {
             return GetDdayScheduleResponse.of(dDaySchedule.get(),
-                    TimeUtil.calculateDaysUntil(dDaySchedule.get().getStartDate()));
+                    TimeUtil.calculateDaysUntil(LocalDate.now(), dDaySchedule.get().getStartDate()));
         }
 
         return GetDdayScheduleResponse.temp();
@@ -183,5 +183,25 @@ public class CalendarService {
                 .thenComparing(sc ->
                         TimeUtil.toStartDateTime(sc.getStartDate(), sc.getStartTime()))
                 .reversed();
+    }
+
+    /**
+     * 해당 유저의 D-Day 일정으로부터 남은 일 수를 반환한다.
+     * <p>
+     * D-Day 일정이 존재하지 않는 경우 {@code null}을 반환한다.
+     * </p>
+     *
+     * @param date   년도, 월, 날짜 정보 (yyyy-MM-dd)
+     * @param userId 유저 ID
+     * @return D-Day 일정으로부터 남은 일 수, 일정이 존재하지 않는 경우 {@code null}
+     */
+    private Integer calculateRemainingDays(LocalDate date, Long userId) {
+        Optional<UserSchedule> dDaySchedule = userScheduleRepository.findByUserIdAndDDayTrue(userId);
+
+        if (dDaySchedule.isPresent()) {
+            return TimeUtil.calculateDaysUntil(date, dDaySchedule.get().getStartDate());
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/application/CalendarService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/application/CalendarService.java
@@ -9,8 +9,6 @@ import com.togedy.togedy_server_v2.domain.schedule.dto.MonthlyScheduleListDto;
 import com.togedy.togedy_server_v2.domain.schedule.entity.ScheduleComparable;
 import com.togedy.togedy_server_v2.domain.schedule.entity.UserSchedule;
 import com.togedy.togedy_server_v2.domain.university.dao.UserUniversityMethodRepository;
-import com.togedy.togedy_server_v2.domain.user.application.UserService;
-import com.togedy.togedy_server_v2.domain.user.dao.UserRepository;
 import com.togedy.togedy_server_v2.global.util.TimeUtil;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -28,10 +26,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CalendarService {
 
-    private final UserRepository userRepository;
     private final UserScheduleRepository userScheduleRepository;
     private final UserUniversityMethodRepository userUniversityMethodRepository;
-    private final UserService userService;
 
     /**
      * 유저의 D-Day 일정까지 남은 일 수와 함께 해당 월에 보유하고 있는 개인 일정 및 대학 일정을 기간이 긴 순서대로 정렬하여 반환한다.

--- a/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dto/GetDailyCalendarResponse.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/schedule/dto/GetDailyCalendarResponse.java
@@ -1,18 +1,19 @@
 package com.togedy.togedy_server_v2.domain.schedule.dto;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @Builder
 public class GetDailyCalendarResponse {
 
-    List<DailyScheduleListDto> dailyScheduleList;
+    private Integer remainingDays;
+    private List<DailyScheduleListDto> dailyScheduleList;
 
-    public static GetDailyCalendarResponse from(List<DailyScheduleListDto> scheduleList) {
+    public static GetDailyCalendarResponse from(Integer remainingDays, List<DailyScheduleListDto> scheduleList) {
         return GetDailyCalendarResponse.builder()
+                .remainingDays(remainingDays)
                 .dailyScheduleList(scheduleList)
                 .build();
     }

--- a/src/main/java/com/togedy/togedy_server_v2/global/util/TimeUtil.java
+++ b/src/main/java/com/togedy/togedy_server_v2/global/util/TimeUtil.java
@@ -47,8 +47,8 @@ public class TimeUtil {
         return LocalDateTime.of(date, Objects.requireNonNullElse(time, LocalTime.MIN));
     }
 
-    public static int calculateDaysUntil(LocalDate startDate) {
-        long remainingDays = ChronoUnit.DAYS.between(LocalDate.now(), startDate);
+    public static int calculateDaysUntil(LocalDate date, LocalDate startDate) {
+        long remainingDays = ChronoUnit.DAYS.between(date, startDate);
         return (int) remainingDays;
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #159

## Work Description ✏️
- 캘린더 일별 조회 API 응답 `remainingDays` 필드 추가


## Uncompleted Tasks 😅
X

## To Reviewers 📢
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 캘린더 조회 시 D-day 남은 날짜 정보가 함께 제공됩니다.

* **개선 사항**
  * D-day 일정의 남은 날짜 계산 로직이 개선되었습니다.
  * 내부 의존성 정리로 서비스 구조가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->