### PR TITLE
[FIX/#170] 스터디 통계 수집 오류 수정

### DIFF
--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/application/StudyTierService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/application/StudyTierService.java
@@ -83,6 +83,7 @@ public class StudyTierService {
             StudyStatistics studyStatistics = studyStatisticsRepository.findByStudyId(challengeStudy.getId())
                     .orElseGet(() -> StudyStatistics.builder()
                             .studyId(challengeStudy.getId())
+                            .updatedDate(targetDate)
                             .build());
 
             studyStatistics.applyChallengeResult(challengeStudy, completedMembers, targetDate);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/application/StudyTierService.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/application/StudyTierService.java
@@ -83,7 +83,7 @@ public class StudyTierService {
             StudyStatistics studyStatistics = studyStatisticsRepository.findByStudyId(challengeStudy.getId())
                     .orElseGet(() -> StudyStatistics.builder()
                             .studyId(challengeStudy.getId())
-                            .updatedDate(targetDate)
+                            .updatedDate(targetDate.minusDays(1))
                             .build());
 
             studyStatistics.applyChallengeResult(challengeStudy, completedMembers, targetDate);

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
@@ -44,11 +44,11 @@ public class StudyStatistics {
     private LocalDate updatedDate;
 
     @Builder
-    public StudyStatistics(Long studyId) {
+    public StudyStatistics(Long studyId, LocalDate updatedDate) {
         this.studyId = studyId;
         this.score = 0;
         this.streakDays = 0;
-        this.updatedDate = LocalDate.MIN;
+        this.updatedDate = updatedDate;
     }
 
     public void applyChallengeResult(Study study, int completedMemberCount, LocalDate targetDate) {

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/entity/StudyStatistics.java
@@ -52,7 +52,7 @@ public class StudyStatistics {
     }
 
     public void applyChallengeResult(Study study, int completedMemberCount, LocalDate targetDate) {
-        if (targetDate.isAfter(this.updatedDate)) {
+        if (!targetDate.isAfter(this.updatedDate)) {
             return;
         }
 

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/scheduler/DailyStudySummaryScheduler.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/scheduler/DailyStudySummaryScheduler.java
@@ -1,4 +1,4 @@
-package com.togedy.togedy_server_v2.domain.study.application.scheduler;
+package com.togedy.togedy_server_v2.domain.study.scheduler;
 
 import com.togedy.togedy_server_v2.domain.study.application.StudyTierService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/scheduler/StudyStatisticsScheduler.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/scheduler/StudyStatisticsScheduler.java
@@ -1,4 +1,4 @@
-package com.togedy.togedy_server_v2.domain.study.application.scheduler;
+package com.togedy.togedy_server_v2.domain.study.scheduler;
 
 import com.togedy.togedy_server_v2.domain.study.application.StudyTierService;
 import lombok.RequiredArgsConstructor;
@@ -7,12 +7,13 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class StudyTierScheduler {
+public class StudyStatisticsScheduler {
 
     private final StudyTierService studyTierService;
 
-    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
-    public void updateStudyTier() {
-        studyTierService.applyStudyTier();
+    @Scheduled(cron = "0 30 5 * * *", zone = "Asia/Seoul")
+    public void calculateChallengeStudyScores() {
+        studyTierService.calculateChallengeStudyScores();
     }
+
 }

--- a/src/main/java/com/togedy/togedy_server_v2/domain/study/scheduler/StudyTierScheduler.java
+++ b/src/main/java/com/togedy/togedy_server_v2/domain/study/scheduler/StudyTierScheduler.java
@@ -1,4 +1,4 @@
-package com.togedy.togedy_server_v2.domain.study.application.scheduler;
+package com.togedy.togedy_server_v2.domain.study.scheduler;
 
 import com.togedy.togedy_server_v2.domain.study.application.StudyTierService;
 import lombok.RequiredArgsConstructor;
@@ -7,13 +7,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class StudyStatisticsScheduler {
+public class StudyTierScheduler {
 
     private final StudyTierService studyTierService;
 
-    @Scheduled(cron = "0 30 5 * * *", zone = "Asia/Seoul")
-    public void calculateChallengeStudyScores() {
-        studyTierService.calculateChallengeStudyScores();
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
+    public void updateStudyTier() {
+        studyTierService.applyStudyTier();
     }
-
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #170

## Work Description ✏️
- StudyStatistics 생성자에 `updatedDate` 컬럼을 임시값인 `LocalDate.MIN`을 사용해 초기화한 뒤, 바로 `targetDate` 값으로 업데이트를 진행하려 했으나, 오버플로우가 발생해 스터디 통계 수집이 원활하게 진행되지 않고 있었습니다.

  따라서 `updatedDate` 초기화 시점부터 `targetDate`값을 사용합니다.

## Uncompleted Tasks 😅
X

## To Reviewers 📢
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 챌린지 스터디의 점수 계산 시 학습 통계 데이터의 업데이트 날짜가 올바르게 초기화되도록 수정되었습니다.

* **리팩토링**
  * 스터디 관련 스케줄러 클래스들의 패키지 구조를 정리하여 전체적인 코드 조직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->